### PR TITLE
docs(workflow-management): encode ephemeral phase isolation and Claude Code session model

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntropic137",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Syntropic137 Agentic Engineering Platform plugin",
   "author": { "name": "Syntropic137" },
   "homepage": "https://github.com/syntropic137/syntropic137",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # syntropic137-claude-plugin
 
-Claude Code plugin for the Syntropic137 platform — commands (`/syn-*`) and skills for orchestration, observability, and setup.
+Claude Code plugin for the Syntropic137 platform: commands (`/syn-*`) and skills for orchestration, observability, and setup.
 
 ## Versioning
 
-**Single source of truth:** `.claude-plugin/plugin.json` → `version` field.
+**Single source of truth:** `.claude-plugin/plugin.json`, `version` field.
 
 **How releases work:**
 
@@ -14,10 +14,10 @@ Claude Code plugin for the Syntropic137 platform — commands (`/syn-*`) and ski
 4. CI (`.github/workflows/plugin-tag.yml`) compares `version` in the pushed commit vs the previous commit. If it changed, it creates and pushes the `v<version>` git tag automatically.
 
 **Rules:**
-- Always bump `plugin.json` when shipping user-visible changes — CI only tags on a version diff.
-- Never manually push a tag that matches a version already in `plugin.json` on `main` — CI will try to create the same tag and fail with "already exists". If you already pushed a tag manually, CI silently skips (idempotent guard), so this is recoverable.
+- Always bump `plugin.json` when shipping user-visible changes: CI only tags on a version diff.
+- Never manually push a tag that matches a version already in `plugin.json` on `main`: CI will try to create the same tag and fail with "already exists". If you already pushed a tag manually, CI silently skips (idempotent guard), so this is recoverable.
 - Use semver: `patch` for fixes/copy changes, `minor` for new commands or skills, `major` for breaking changes.
-- Do **not** bump the version in the same commit as the code change if you want a clean one-liner history — a separate `chore: bump plugin version to x.y.z` commit is fine.
+- Do **not** bump the version in the same commit as the code change if you want a clean one-liner history: a separate `chore: bump plugin version to x.y.z` commit is fine.
 
 **Example flow:**
 
@@ -56,11 +56,11 @@ claude plugin install syntropic137@syntropic137
 
 ## Hooks
 
-`hooks/hooks.json` is **loaded automatically** by Claude Code — do NOT reference it in `plugin.json`. Only add a `"hooks"` field to `plugin.json` if you have a *second* hooks file at a non-standard path.
+`hooks/hooks.json` is **loaded automatically** by Claude Code: do NOT reference it in `plugin.json`. Only add a `"hooks"` field to `plugin.json` if you have a *second* hooks file at a non-standard path.
 
 ## Security
 
-See [./SECURITY.md](./SECURITY.md) for the full security model. The critical rule: **secrets must never enter Claude's context window.** All credential input uses `!` prefix (external shell execution), file paths instead of file content, and `grep -q` status checks instead of value reads. Contributors must follow these patterns — see the rules in SECURITY.md before touching any setup or secrets code.
+See [./SECURITY.md](./SECURITY.md) for the full security model. The critical rule: **secrets must never enter Claude's context window.** All credential input uses `!` prefix (external shell execution), file paths instead of file content, and `grep -q` status checks instead of value reads. Contributors must follow these patterns: see the rules in SECURITY.md before touching any setup or secrets code.
 
 ## Claude Code Documentation
 
@@ -77,4 +77,4 @@ Use colons `:` and commas `,` instead of dashes or em dashes in prose. This appl
 
 ## Scratch files
 
-Root-level `.md` files (except `README.md`, `CLAUDE.md`, `SECURITY.md`) are scratch — never commit them.
+Root-level `.md` files (except `README.md`, `CLAUDE.md`, `SECURITY.md`) are scratch: never commit them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,19 @@ claude plugin install syntropic137@syntropic137
 
 See [./SECURITY.md](./SECURITY.md) for the full security model. The critical rule: **secrets must never enter Claude's context window.** All credential input uses `!` prefix (external shell execution), file paths instead of file content, and `grep -q` status checks instead of value reads. Contributors must follow these patterns — see the rules in SECURITY.md before touching any setup or secrets code.
 
+## Claude Code Documentation
+
+When authoring workflow phases, skills, or commands, reference the official Claude Code docs:
+
+- Commands reference: https://code.claude.com/docs/en/commands.md
+- Skills reference: https://code.claude.com/docs/en/skills.md
+
+Each Syntropic137 workflow phase is a Claude CLI invocation. Phase prompts can invoke slash commands and skills directly. Workflow authors should be familiar with what commands and skills are available.
+
+## Writing Style
+
+Use colons `:` and commas `,` instead of dashes or em dashes in prose. This applies to all skill files, commands, and documentation.
+
 ## Scratch files
 
 Root-level `.md` files (except `README.md`, `CLAUDE.md`, `SECURITY.md`) are scratch — never commit them.

--- a/skills/workflow-management/SKILL.md
+++ b/skills/workflow-management/SKILL.md
@@ -17,7 +17,7 @@ Not needed when you just want to **run** an existing workflow; use the execution
 
 ## Phases Are Claude Code Sessions
 
-Each workflow phase is a full Claude Code CLI invocation. That means phase prompts can invoke any slash command (`/syn-*`, `/commit`, `/review`, etc.) and any installed skill directly by name. When designing a phase prompt, consult the Claude Code commands and skills references to know what's available:
+Each workflow phase is a full Claude CLI invocation. That means phase prompts can invoke any slash command (`/syn-*`, `/commit`, `/review`, etc.) and any installed skill directly by name. When designing a phase prompt, consult the Claude Code commands and skills references to know what's available:
 
 - Commands: https://code.claude.com/docs/en/commands.md
 - Skills: https://code.claude.com/docs/en/skills.md
@@ -104,7 +104,7 @@ See `workflow-management` skill for full YAML schema reference including `allowe
 
 **Missing `input_declarations` for inputs used in prompts.** If `{{repository}}` appears in a prompt but isn't declared, it won't be substituted. Validate the workflow before registering.
 
-**Splitting git operations across phases.** If phase 1 commits code and phase 2 tries to push or open a PR, phase 2 will start with a clean workspace and find nothing to push. All git operations, commit, push, `gh pr create`, must happen in the same phase that wrote the changes. If the workflow design requires separating research/implementation from the git step, have the implementation phase output a patch artifact and have the git phase apply it in a fresh clone.
+**Splitting git operations across phases.** If phase 1 commits code and phase 2 tries to push or open a PR, phase 2 will start with a clean workspace and find nothing to push. All git operations, including commit, push, and `gh pr create`, must happen in the same phase that wrote the changes. If the workflow design requires separating research/implementation from the git step, have the implementation phase output a patch artifact and have the git phase apply it in a fresh clone.
 
 **Skipping HUMAN_IN_LOOP on destructive workflows.** Any workflow that writes, commits, or deploys should pause for human review. Automation without oversight is how you get force-pushed to main at 2am.
 

--- a/skills/workflow-management/SKILL.md
+++ b/skills/workflow-management/SKILL.md
@@ -15,11 +15,22 @@ Use this when you are: designing a new workflow template, debugging unexpected p
 
 Not needed when you just want to **run** an existing workflow; use the execution-control skill instead. Not needed when you want to list or inspect already-registered workflows; use `/syn-workflow` for that.
 
+## Phases Are Claude Code Sessions
+
+Each workflow phase is a full Claude Code CLI invocation. That means phase prompts can invoke any slash command (`/syn-*`, `/commit`, `/review`, etc.) and any installed skill directly by name. When designing a phase prompt, consult the Claude Code commands and skills references to know what's available:
+
+- Commands: https://code.claude.com/docs/en/commands.md
+- Skills: https://code.claude.com/docs/en/skills.md
+
+Write phase prompts the same way you'd write instructions to Claude Code in a terminal session.
+
 ## The Core Model: Templates vs Executions
 
 A **workflow template** is a reusable definition (like a class). A **workflow execution** is a running instance (like an object). One template can have many concurrent executions with different tasks, repos, and inputs.
 
 Templates define **phases**: each phase is one Claude CLI invocation in its own workspace. Phases run sequentially by default; outputs from phase N feed into phase N+1 via `{{phase-id}}` substitution.
+
+**Phase workspaces are ephemeral.** Each phase starts in a fresh Docker container: no git branches, staged files, commits, or file changes from a prior phase carry over. The only thing that crosses a phase boundary is the artifact output. If a phase needs to do git work (commit, push, `gh pr create`), it must do so in the same phase that made the changes. If a later phase needs those changes, either collapse the phases or have the earlier phase output a patch/diff artifact that the later phase applies.
 
 ## Designing a Workflow: 4 Phases
 
@@ -92,6 +103,8 @@ See `workflow-management` skill for full YAML schema reference including `allowe
 **Every phase using opus.** Costs scale fast with opus. Audit your model assignments whenever a workflow runs expensive.
 
 **Missing `input_declarations` for inputs used in prompts.** If `{{repository}}` appears in a prompt but isn't declared, it won't be substituted. Validate the workflow before registering.
+
+**Splitting git operations across phases.** If phase 1 commits code and phase 2 tries to push or open a PR, phase 2 will start with a clean workspace and find nothing to push. All git operations, commit, push, `gh pr create`, must happen in the same phase that wrote the changes. If the workflow design requires separating research/implementation from the git step, have the implementation phase output a patch artifact and have the git phase apply it in a fresh clone.
 
 **Skipping HUMAN_IN_LOOP on destructive workflows.** Any workflow that writes, commits, or deploys should pause for human review. Automation without oversight is how you get force-pushed to main at 2am.
 


### PR DESCRIPTION
Closes #33

## Summary

- Add **Phase workspaces are ephemeral** callout in the Core Model section: each phase starts in a fresh Docker container, no git state carries over, artifact output is the only cross-phase bridge
- Add **Splitting git operations across phases** to Common Mistakes: concrete failure scenario (commit in phase 1, push in phase 2) and correct patterns (collapse phases, or patch artifact + apply)
- Add **Phases Are Claude Code Sessions** section: each phase is a full Claude Code CLI invocation, phase prompts can invoke slash commands and skills, with links to the official commands and skills docs
- Add **Claude Code Documentation** section to CLAUDE.md with reference URLs for commands and skills
- Add **Writing Style** section to CLAUDE.md: use colons and commas over dashes and em dashes

## Test plan

- [ ] Read `skills/workflow-management/SKILL.md` and verify the ephemeral phase callout is clear and accurate
- [ ] Verify no em dashes remain in the changed files
- [ ] Verify the Claude Code doc links are present in both CLAUDE.md and the skill