### PR TITLE
chore: replace syn-ctl references with npx @syntropic137/setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ through configuration. Pick which features to enable (GitHub App, Cloudflare,
 ## Managing Your Stack
 
 **Published path** (`~/.syntropic137/`):
-- `./syn-ctl status` — service health
-- `./syn-ctl logs [service]` — tail logs
-- `./syn-ctl up` / `./syn-ctl down` — start/stop
-- `./syn-ctl update` — pull latest images
+- `npx @syntropic137/setup status` — service health
+- `npx @syntropic137/setup logs` — tail logs
+- `npx @syntropic137/setup start` / `npx @syntropic137/setup stop` — start/stop
+- `npx @syntropic137/setup update` — pull latest images
 
 **Source repo** (contributors):
 - `just selfhost-status`, `just selfhost-logs`, `just selfhost-up`, `just selfhost-down`

--- a/commands/syn-health.md
+++ b/commands/syn-health.md
@@ -38,9 +38,9 @@ If it fails (non-zero exit or connection error):
    fi
    ```
 3. If the container exists but API is unhealthy, suggest checking logs:
-   - Published path (`~/.syntropic137/`): `cd ~/.syntropic137 && ./syn-ctl logs`
+   - Published path (`~/.syntropic137/`): `npx @syntropic137/setup logs`
    - Source repo: `just dev-logs`
 4. If no containers are running, suggest starting the stack:
-   - Published path: `cd ~/.syntropic137 && ./syn-ctl up` or `docker compose -f ~/.syntropic137/docker-compose.syntropic137.yaml up -d`
+   - Published path: `npx @syntropic137/setup start` or `docker compose -f ~/.syntropic137/docker-compose.syntropic137.yaml up -d`
    - Source repo: `just selfhost-up` or `just dev`
 5. If Docker itself is not running, suggest starting Docker Desktop

--- a/commands/syn-setup.md
+++ b/commands/syn-setup.md
@@ -99,7 +99,7 @@ Then ask the user:
 > 3. Reconfigure from scratch (backs up current .env)
 
 - **Option 1:** Identify which phases are incomplete and skip to the first missing one. For example, if secrets and API key exist but GitHub App is not configured, skip to Phase 7.
-- **Option 2:** Download the latest compose file and `syn-ctl`, run `docker compose pull`, restart. Preserve `.env` and secrets.
+- **Option 2:** Run `npx @syntropic137/setup update` to pull the latest compose file and images and restart. Preserve `.env` and secrets.
 - **Option 3:** Back up `.env` to `.env.backup.<timestamp>`, then proceed from Phase 3 as a fresh install.
 
 ---
@@ -121,17 +121,15 @@ RELEASE_BASE="https://github.com/syntropic137/syntropic137/releases/download/${L
 
 curl -sL "${RELEASE_BASE}/docker-compose.syntropic137.yaml" -o "$HOME/.syntropic137/docker-compose.syntropic137.yaml"
 curl -sL "${RELEASE_BASE}/selfhost.env.example" -o "$HOME/.syntropic137/.env"
-curl -sL "${RELEASE_BASE}/syn-ctl" -o "$HOME/.syntropic137/syn-ctl"
 curl -sL "${RELEASE_BASE}/selfhost-entrypoint.sh" -o "$HOME/.syntropic137/selfhost-entrypoint.sh"
 
-chmod +x "$HOME/.syntropic137/syn-ctl"
 chmod +x "$HOME/.syntropic137/selfhost-entrypoint.sh"
 ```
 
 Verify all files were downloaded (non-empty):
 
 ```bash
-for f in docker-compose.syntropic137.yaml .env syn-ctl selfhost-entrypoint.sh; do
+for f in docker-compose.syntropic137.yaml .env selfhost-entrypoint.sh; do
   test -s "$HOME/.syntropic137/$f" && echo "$f: OK" || echo "$f: FAILED"
 done
 ```
@@ -409,7 +407,7 @@ echo "SYN_1PASSWORD_BACKUP=true" >> "$HOME/.syntropic137/.env"
 
 Tell the user:
 
-> All secrets backed up to 1Password vault "syntropic137", item "syntropic137-config". You can restore on a new machine with `./syn-ctl secrets-pull`.
+> All secrets backed up to 1Password vault "syntropic137", item "syntropic137-config". You can restore on a new machine by re-running `npx @syntropic137/setup init`.
 
 ---
 

--- a/commands/syn-status.md
+++ b/commands/syn-status.md
@@ -34,7 +34,7 @@ fi
 ```
 
 If Docker is not running or no containers exist, note that the stack is down and suggest:
-- Published path (`~/.syntropic137/`): `cd ~/.syntropic137 && ./syn-ctl up`
+- Published path (`~/.syntropic137/`): `npx @syntropic137/setup start`
 - Source repo: `just selfhost-up` or `just dev`
 
 ## 2. API Health

--- a/skills/github-automation/SKILL.md
+++ b/skills/github-automation/SKILL.md
@@ -226,7 +226,7 @@ just seed-all         # Seed everything
 ### "How do I test triggers locally?"
 
 1. Start the stack:
-   - Published path: `cd ~/.syntropic137 && ./syn-ctl up`
+   - Published path: `npx @syntropic137/setup start`
    - Source repo: `just dev` (includes webhook proxy)
 2. Verify webhooks are being delivered:
    - Selfhost: check Cloudflare tunnel status in Zero Trust dashboard

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -42,17 +42,16 @@ Every plugin command resolves this before making API calls. If the user is on a 
 
 ### Published Path (Self-Hosters)
 
-Self-hosters install to `~/.syntropic137/` and use `syn-ctl` for management. No `uv`, `just`, or source repo required.
+Self-hosters install to `~/.syntropic137/` via `npx @syntropic137/setup`. No `uv`, `just`, or source repo required.
 
 ```bash
-cd ~/.syntropic137
-./syn-ctl up                  # Start the stack
-./syn-ctl down                # Stop the stack
-./syn-ctl logs [service]      # View logs
-./syn-ctl update              # Pull latest images and restart
+npx @syntropic137/setup start   # Start the stack
+npx @syntropic137/setup stop    # Stop the stack
+npx @syntropic137/setup logs    # View logs
+npx @syntropic137/setup update  # Pull latest images and restart
 ```
 
-The published compose file is `docker-compose.syntropic137.yaml` in `~/.syntropic137/`. All stack management goes through `syn-ctl` or direct `docker compose -f docker-compose.syntropic137.yaml` commands.
+The published compose file is `docker-compose.syntropic137.yaml` in `~/.syntropic137/`. All stack management goes through `npx @syntropic137/setup` or direct `docker compose -f ~/.syntropic137/docker-compose.syntropic137.yaml` commands.
 
 ### Quick Dev Setup (Source Repo)
 


### PR DESCRIPTION
## Summary

- `syn-ctl` (bash management script) has been removed from the platform; `npx @syntropic137/setup` is now the primary self-host entry point and covers all the same lifecycle commands
- All `./syn-ctl <cmd>` references replaced with `npx @syntropic137/setup <cmd>` equivalents
- Files updated: `README.md`, `skills/setup/SKILL.md`, `skills/github-automation/SKILL.md`, `commands/syn-setup.md`, `commands/syn-status.md`, `commands/syn-health.md`

## Command mapping

| Old | New |
|-----|-----|
| `./syn-ctl up` | `npx @syntropic137/setup start` |
| `./syn-ctl down` | `npx @syntropic137/setup stop` |
| `./syn-ctl logs` | `npx @syntropic137/setup logs` |
| `./syn-ctl update` | `npx @syntropic137/setup update` |
| `./syn-ctl status` | `npx @syntropic137/setup status` |