### PR TITLE
chore: remove remaining syn-ctl references

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntropic137",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Syntropic137 Agentic Engineering Platform plugin",
   "author": { "name": "Syntropic137" },
   "homepage": "https://github.com/syntropic137/syntropic137",

--- a/commands/syn-health.md
+++ b/commands/syn-health.md
@@ -46,9 +46,9 @@ If it fails (non-zero exit or connection error):
    fi
    ```
 3. If the container exists but API is unhealthy, suggest checking logs:
-   - Published path (`~/.syntropic137/`): `cd ~/.syntropic137 && ./syn-ctl logs`
+   - Published path (`~/.syntropic137/`): `docker compose -f ~/.syntropic137/docker-compose.syntropic137.yaml logs`
    - Source repo: `just dev-logs`
 4. If no containers are running, suggest starting the stack:
-   - Published path: `cd ~/.syntropic137 && ./syn-ctl up` or `docker compose -f ~/.syntropic137/docker-compose.syntropic137.yaml up -d`
+   - Published path: `npx @syntropic137/setup` (interactive menu) or `docker compose -f ~/.syntropic137/docker-compose.syntropic137.yaml up -d`
    - Source repo: `just selfhost-up` or `just dev`
 5. If Docker itself is not running, suggest starting Docker Desktop

--- a/commands/syn-status.md
+++ b/commands/syn-status.md
@@ -44,7 +44,7 @@ fi
 ```
 
 If Docker is not running or no containers exist, note that the stack is down and suggest:
-- Published path (`~/.syntropic137/`): `cd ~/.syntropic137 && ./syn-ctl up`
+- Published path (`~/.syntropic137/`): `npx @syntropic137/setup` (interactive menu) or `docker compose -f ~/.syntropic137/docker-compose.syntropic137.yaml up -d`
 - Source repo: `just selfhost-up` or `just dev`
 
 ## 2. API Health


### PR DESCRIPTION
## Summary

`syn-ctl` (848-line bash management script) is being removed from the platform in [syntropic137/syntropic137#708](https://github.com/syntropic137/syntropic137/pull/708). The recent skills rewrite (superpowers pattern, #30) already migrated `README.md`, all `skills/*/SKILL.md`, and `commands/syn-setup.md` to use `npx @syntropic137/setup`. Two slash-command files were missed; this PR finishes the job.

## Changes

| File | Change |
|------|--------|
| `commands/syn-health.md` | `./syn-ctl logs` → `docker compose … logs`; `./syn-ctl up` → `npx @syntropic137/setup` (interactive menu) |
| `commands/syn-status.md` | `./syn-ctl up` → `npx @syntropic137/setup` (interactive menu) |
| `.claude-plugin/plugin.json` | Version bump 0.11.2 → 0.11.3 (content change) |

## Verification

After this PR, `grep -r syn-ctl .` returns zero hits across the plugin.