### PR TITLE
docs(setup): document SYN_API_PASSWORD + bump to 0.11.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syntropic137",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Syntropic137 Agentic Engineering Platform plugin",
   "author": { "name": "Syntropic137" },
   "homepage": "https://github.com/syntropic137/syntropic137",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -63,7 +63,7 @@ Two files are kept separate to isolate application config from infrastructure co
 
 **Root `.env`** (application): `ANTHROPIC_API_KEY`, `SYN_GITHUB_APP_ID`, `SYN_GITHUB_APP_NAME`, `SYN_GITHUB_WEBHOOK_SECRET`, `APP_ENVIRONMENT`
 
-**`infra/.env`** (infrastructure): `CLOUDFLARE_TUNNEL_TOKEN`, `SYN_PUBLIC_HOSTNAME`, `POSTGRES_PASSWORD`, `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `REDIS_PASSWORD`, `SYN_API_PASSWORD` (selfhost basic-auth password for the gateway, gates the LAN and global tiers, see ADR-059)
+**`infra/.env`** (infrastructure): `CLOUDFLARE_TUNNEL_TOKEN`, `SYN_PUBLIC_HOSTNAME`, `POSTGRES_PASSWORD`, `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `REDIS_PASSWORD`, `SYN_API_PASSWORD` (selfhost basic-auth password for the gateway, gates the LAN and global tiers; see ADR-059 in the parent Syntropic137 repository's ADR documentation)
 
 Run `just dev-doctor` to diagnose env var issues.
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -63,7 +63,7 @@ Two files are kept separate to isolate application config from infrastructure co
 
 **Root `.env`** (application): `ANTHROPIC_API_KEY`, `SYN_GITHUB_APP_ID`, `SYN_GITHUB_APP_NAME`, `SYN_GITHUB_WEBHOOK_SECRET`, `APP_ENVIRONMENT`
 
-**`infra/.env`** (infrastructure): `CLOUDFLARE_TUNNEL_TOKEN`, `SYN_PUBLIC_HOSTNAME`, `POSTGRES_PASSWORD`, `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `REDIS_PASSWORD`
+**`infra/.env`** (infrastructure): `CLOUDFLARE_TUNNEL_TOKEN`, `SYN_PUBLIC_HOSTNAME`, `POSTGRES_PASSWORD`, `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `REDIS_PASSWORD`, `SYN_API_PASSWORD` (selfhost basic-auth password for the gateway, gates the LAN and global tiers, see ADR-059)
 
 Run `just dev-doctor` to diagnose env var issues.
 


### PR DESCRIPTION
No issue: small doc-restoration fix, not behavior change.

## Summary

- The recent SKILL.md rewrite dropped `SYN_API_PASSWORD` from the `infra/.env` env-var list. It is required for selfhost installs (gates the LAN and global access tiers per ADR-059), so its absence makes the docs misleading.
- Re-adds it to the prose list with a short ADR-059 reference inline.
- Bumps plugin version to 0.11.6 (patch, doc-only). Per CLAUDE.md, this triggers the auto-tag CI on merge.

## Test plan

- [ ] CI green on the PR.
- [ ] After merge, verify CI auto-tagged v0.11.6 (per `.github/workflows/plugin-tag.yml`).
- [ ] Update parent repo (syntropic137/syntropic137) submodule pointer to the new merged commit.